### PR TITLE
Only emit the project name when printing requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ classifiers =
 [options]
 install_requires =
   setuptools
+python_requires = ">=3.6"
 packages =
   setupcfg2nix
 

--- a/setupcfg2nix/__init__.py
+++ b/setupcfg2nix/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 0)
+VERSION = (1, 1, 0)

--- a/setupcfg2nix/cli.py
+++ b/setupcfg2nix/cli.py
@@ -1,6 +1,55 @@
-from __future__ import print_function
 from setuptools.config import read_configuration
 import argparse
+import unittest.mock
+import errno
+import os
+import os.path
+import tempfile
+import setuptools
+import sys
+from distutils.errors import DistutilsFileError
+
+requires_sets = [ "install_requires", "setup_requires", "tests_require" ]
+
+def make_declarative(package_dir, out_file):
+    cur_dir = os.getcwd()
+    cur_path = sys.path[:]
+    try:
+        os.chdir(package_dir)
+        sys.path.insert(0, '.')
+        with unittest.mock.patch.object(setuptools, 'setup') as mock_setup:
+            import setup
+
+            args, kwargs = mock_setup.call_args
+    finally:
+        os.chdir(cur_dir)
+        sys.path = cur_path
+
+    out_file.write("[metadata]\n")
+    out_file.write(f"name = {kwargs['name']}\n")
+    out_file.write(f"version = {kwargs['version']}\n\n")
+    out_file.write("[options]\n")
+    for r in requires_sets:
+        deps = kwargs.get(r, [])
+        if deps:
+            out_file.write(f"{r} =\n")
+            for dep in deps:
+                out_file.write(f"  {dep}\n")
+
+class IncompleteConfig(Exception):
+    pass
+
+def read_configuration_with_fallback(cfg_path):
+    try:
+        cfg = read_configuration(cfg_path)
+        if 'metadata' not in cfg or 'name' not in cfg['metadata']:
+            raise IncompleteConfig
+        return cfg
+    except (IncompleteConfig, DistutilsFileError) as e:
+        with tempfile.NamedTemporaryFile(mode='w+', prefix='setup.cfg') as tmp:
+            make_declarative(os.path.dirname(cfg_path), tmp)
+            tmp.flush()
+            return read_configuration_with_fallback(tmp.name)
 
 def main():
     """Parses a setup.cfg file and prints a nix representation to stdout.
@@ -16,14 +65,17 @@ def main():
     """
     parser = argparse.ArgumentParser(description='Parse a setuptools setup.cfg into nix expressions')
     parser.add_argument('cfg', metavar='CFG', nargs='?', default='setup.cfg', help='The path to the configuration file (defaults to setup.cfg)')
+    parser.add_argument('--allow-autogeneration', action='store_true', help='Allow autogeneration of setup.cfg from setup.py when declarative setup.cfg is not available (runs python code in setup.py!)')
     args = parser.parse_args()
-    cfg = read_configuration(args.cfg)
+    if args.allow_autogeneration:
+        cfg = read_configuration_with_fallback(args.cfg)
+    else:
+        cfg = read_configuration(args.cfg)
     print('{ pname            = "', cfg['metadata']['name'], '";', sep='')
     print('  version          = "', cfg['metadata']['version'], '";', sep='')
 
-    print_dependencies(cfg, 'install_requires')
-    print_dependencies(cfg, 'setup_requires')
-    print_dependencies(cfg, 'tests_require')
+    for r in requires_sets:
+        print_dependencies(cfg, r)
 
     print('}')
 

--- a/setupcfg2nix/cli.py
+++ b/setupcfg2nix/cli.py
@@ -1,4 +1,5 @@
 from setuptools.config import read_configuration
+from pkg_resources import Requirement
 import argparse
 import unittest.mock
 import errno
@@ -83,9 +84,10 @@ def print_dependencies(cfg, name):
     deps = cfg['options'].get(name, [])
     if deps:
         print('  ' + name + ' = ')
-        print('    [ "', deps[0], '"', sep='')
+        # TODO should we care about 'extras'?
+        print('    [ "', Requirement.parse(deps[0]).project_name, '"', sep='')
         for req in deps[1:]:
-            print('      "', req, '"', sep='')
+            print('      "', Requirement.parse(req).project_name, '"', sep='')
         print('    ];')
 
 if __name__ == '__main__':


### PR DESCRIPTION
On top of #1 to avoid conflicts.