### PR TITLE
Remove autogeneration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,3 @@ by `pythonPackages.buildSetupcfg` in [nixpkgs]. See the
 
 [nixpkgs]: https://nixos.org/nixpkgs
 [documentation]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/build-setupcfg/default.nix
-
-Packages without setup.cfg
----------------------------
-
-For packages lacking a declarative `setup.cfg`, `setupcfg2nix` can try
-to generate one as an intermediate temporary file and generate nix
-expressions anyway. This involves running potentially untrusted python
-code, so it requires the `--allow-autogeneration` flag to be enabled.
-If the requested `setup.cfg` doesn't exist or does not contain the
-full package metadata, `setupcfg2nix` will use `setup.py` in the same
-directory instead.

--- a/setupcfg2nix/__init__.py
+++ b/setupcfg2nix/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 1, 0)
+VERSION = (2, 0, 0)

--- a/setupcfg2nix/cli.py
+++ b/setupcfg2nix/cli.py
@@ -1,56 +1,9 @@
 from setuptools.config import read_configuration
 from pkg_resources import Requirement
 import argparse
-import unittest.mock
-import errno
-import os
-import os.path
-import tempfile
 import setuptools
-import sys
-from distutils.errors import DistutilsFileError
 
 requires_sets = [ "install_requires", "setup_requires", "tests_require" ]
-
-def make_declarative(package_dir, out_file):
-    cur_dir = os.getcwd()
-    cur_path = sys.path[:]
-    try:
-        os.chdir(package_dir)
-        sys.path.insert(0, '.')
-        with unittest.mock.patch.object(setuptools, 'setup') as mock_setup:
-            import setup
-
-            args, kwargs = mock_setup.call_args
-    finally:
-        os.chdir(cur_dir)
-        sys.path = cur_path
-
-    out_file.write("[metadata]\n")
-    out_file.write(f"name = {kwargs['name']}\n")
-    out_file.write(f"version = {kwargs['version']}\n\n")
-    out_file.write("[options]\n")
-    for r in requires_sets:
-        deps = kwargs.get(r, [])
-        if deps:
-            out_file.write(f"{r} =\n")
-            for dep in deps:
-                out_file.write(f"  {dep}\n")
-
-class IncompleteConfig(Exception):
-    pass
-
-def read_configuration_with_fallback(cfg_path):
-    try:
-        cfg = read_configuration(cfg_path)
-        if 'metadata' not in cfg or 'name' not in cfg['metadata']:
-            raise IncompleteConfig
-        return cfg
-    except (IncompleteConfig, DistutilsFileError) as e:
-        with tempfile.NamedTemporaryFile(mode='w+', prefix='setup.cfg') as tmp:
-            make_declarative(os.path.dirname(cfg_path), tmp)
-            tmp.flush()
-            return read_configuration_with_fallback(tmp.name)
 
 def main():
     """Parses a setup.cfg file and prints a nix representation to stdout.
@@ -59,7 +12,6 @@ def main():
 
     Args:
         cfg (str): The path to the setup.cfg file, defaults to 'setup.cfg' in the current directory
-        allow_autogeneration (bool): Whether to fall-back to autogeneration from the setup.py in the same directory as 'cfg' if 'cfg' is inadequate.
 
     Returns:
         None: Prints to stdout
@@ -67,12 +19,8 @@ def main():
     """
     parser = argparse.ArgumentParser(description='Parse a setuptools setup.cfg into nix expressions')
     parser.add_argument('cfg', metavar='CFG', nargs='?', default='setup.cfg', help='The path to the configuration file (defaults to setup.cfg)')
-    parser.add_argument('--allow-autogeneration', action='store_true', help='Allow autogeneration of setup.cfg from setup.py when declarative setup.cfg is not available (runs python code in setup.py!)')
     args = parser.parse_args()
-    if args.allow_autogeneration:
-        cfg = read_configuration_with_fallback(args.cfg)
-    else:
-        cfg = read_configuration(args.cfg)
+    cfg = read_configuration(args.cfg)
     print('{')
     print(f"  pname = ''{cfg['metadata']['name']}'';")
     print(f"  version = ''{cfg['metadata']['version']}'';")


### PR DESCRIPTION
The existing implementation falls short in too many ways, and
the (hopefully!) full version is way too hacky to live here. We'll
keep it as a separate project.