### PR TITLE
Removed quotes around python_requires in setup.cfg to prevent build e…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
 [options]
 install_requires =
   setuptools
-python_requires = ">=3.6"
+python_requires = >=3.6
 packages =
   setupcfg2nix
 


### PR DESCRIPTION
Fixes https://github.com/target/setupcfg2nix/issues/6 

## Tests

To verify, run:
```
nix-shell -p python3 -p "python3Packages.setuptools" --run "python3 ./setupcfg2nix/cli.py ./setup.cfg"
``` 

And the script will exit successfully. 

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/14322653/77965713-77df3880-7296-11ea-9b89-d4bc98d6bee7.png">


On master branch, this same command will throw an exception:

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/14322653/77965625-42d2e600-7296-11ea-905c-8e0f4682d9c4.png">
